### PR TITLE
Fix google drive issue.

### DIFF
--- a/VideoHosting/src/App.tsx
+++ b/VideoHosting/src/App.tsx
@@ -10,7 +10,7 @@ function App() {
         <h1>Video Host Test Site</h1>
         <div className='video-wrapper'>
           <h2>The Video</h2>
-          <iframe src='https://drive.google.com/file/d/1PzPM0dR9gc7Mie478qKA5Sbf6Luvjs12/view?usp=sharing' width="640" height="480"></iframe>
+          <iframe src="https://drive.google.com/file/d/1_dNZkGDGQoaPHsJHzzm3EhAoweSwLYsg/preview" width="640" height="480" allow="autoplay"></iframe>
           
           <img src="https://drive.google.com/thumbnail?id=1PzPM0dR9gc7Mie478qKA5Sbf6Luvjs12&sz=w1000" alt="None"/>
           <video src='https://drive.google.com/thumbnail?id=1PzPM0dR9gc7Mie478qKA5Sbf6Luvjs12&sz=w1000'></video>


### PR DESCRIPTION
The issue is that you can't just use the share link in order to embed a video in the iframe I believe. If you click the 3 dots in the top right when viewing a video on google drive, you can open the video in a new window. Then if you click the three dots on that page there is an embed video option lol. This little code snippet is how you get the embed link/element.

(also make sure the video is publicly viewable but I think you already did that)


https://support.google.com/blogger/thread/1950766/how-do-i-embed-videos-from-my-google-drive-google-photos-into-a-blogger-post-embed-is-no-more?hl=en